### PR TITLE
Configure Travis to use Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+
+env:
+  - CXX=g++-4.8
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+
+matrix:
+  allow_failures:
+    - rust: nightly
+
+before_install:
+  - source $HOME/.nvm/nvm.sh
+  - nvm install stable
+  - nvm use stable

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <img align="right" src="neon.jpg" alt="neon"/>
 
+[![Build Status](https://travis-ci.org/rustbridge/neon.svg?branch=master)](https://travis-ci.org/rustbridge/neon)
 [![](http://meritbadge.herokuapp.com/neon)](https://crates.io/crates/neon)
 
 A safe Rust abstraction layer for native Node.js modules.


### PR DESCRIPTION
- Travis uses Node 0.10 and an old version of g++ that is not C++11 compatible. This PR ensures node stable and g++-4.8 are installed.
- Runs on rust stable, beta & nightly. Nightly is allowed to fail without affecting the build.