### PR TITLE
Make travis happy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod js;
 ///
 /// Example:
 ///
-/// ```rust
+/// ```rust,ignore
 /// register_module!(m, {
 ///     try!(m.export("foo", foo));
 ///     try!(m.export("bar", bar));


### PR DESCRIPTION
This avoids running the code that uses the `register_module` macro in the docs, which requires other things in order to be compiled.