### PR TITLE
User defined classes

### DIFF
--- a/crates/neon-sys/src/buf.rs
+++ b/crates/neon-sys/src/buf.rs
@@ -4,7 +4,6 @@ use std::mem;
 use std::str;
 
 #[repr(C)]
-#[allow(raw_pointer_derive)]
 #[derive(Copy, Clone)]
 pub struct Buf<'a> {
     ptr: *mut u8,

--- a/crates/neon-sys/src/call.rs
+++ b/crates/neon-sys/src/call.rs
@@ -6,7 +6,10 @@ extern "system" {
     pub fn set_return(info: &FunctionCallbackInfo, value: Local);
 
     #[link_name = "NeonSys_Call_GetIsolate"]
-    pub fn get_isolate(info: &FunctionCallbackInfo) -> &Isolate;
+    pub fn get_isolate(info: &FunctionCallbackInfo) -> *mut Isolate;
+
+    #[link_name = "NeonSys_Call_CurrentIsolate"]
+    pub fn current_isolate() -> *mut Isolate;
 
     #[link_name = "NeonSys_Call_IsConstruct"]
     pub fn is_construct(info: &FunctionCallbackInfo) -> bool;

--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -41,7 +41,7 @@ extern "system" {
     pub fn get_call_kernel(obj: Local) -> *mut c_void;
 
     #[link_name = "NeonSys_Class_Constructor"]
-    pub fn constructor(out: &mut Local, ft: Local);
+    pub fn constructor(out: &mut Local, ft: Local) -> bool;
 
     #[link_name = "NeonSys_Class_Check"]
     pub fn check(c: Local, v: Local) -> bool;

--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -19,6 +19,12 @@ extern "system" {
     #[link_name = "NeonSys_Class_SetName"]
     pub fn set_name(isolate: *mut Isolate, metadata: *mut c_void, name: *const u8, byte_length: u32) -> bool;
 
+    #[link_name = "NeonSys_Class_ThrowCallError"]
+    pub fn throw_call_error(isolate: *mut Isolate, metadata: *mut c_void);
+
+    #[link_name = "NeonSys_Class_ThrowThisError"]
+    pub fn throw_this_error(isolate: *mut Isolate, metadata: *mut c_void);
+
     #[link_name = "NeonSys_Class_AddMethod"]
     pub fn add_method(isolate: *mut Isolate, metadata: *mut c_void, name: *const u8, byte_length: u32, method: Local) -> bool;
 

--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -1,0 +1,35 @@
+use std::os::raw::c_void;
+use raw::{FunctionCallbackInfo, Isolate, Local};
+
+extern "system" {
+
+    #[link_name = "NeonSys_Class_ForConstructor"]
+    pub fn for_constructor(info: &FunctionCallbackInfo, out: &mut Local);
+
+    #[link_name = "NeonSys_Class_ForMethod"]
+    pub fn for_method(info: &FunctionCallbackInfo, out: &mut Local);
+
+    #[link_name = "NeonSys_Class_Create"]
+    pub fn create(out: &mut Local, isolate: *mut Isolate, callback: *mut c_void, construct_kernel: *mut c_void) -> bool;
+
+    #[link_name = "NeonSys_Class_GetConstructorKernel"]
+    pub fn get_constructor_kernel(obj: Local) -> *mut c_void;
+
+    #[link_name = "NeonSys_Class_ExecConstructorKernel"]
+    pub fn exec_constructor_kernel(closure: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), info: &FunctionCallbackInfo, scope: *mut c_void);
+
+    #[link_name = "NeonSys_Class_Constructor"]
+    pub fn constructor(out: &mut Local, ft: Local);
+
+    #[link_name = "NeonSys_Class_Check"]
+    pub fn check(c: Local, v: Local) -> bool;
+
+    #[link_name = "NeonSys_Class_GetInstanceInternals"]
+    pub fn get_instance_internals(obj: Local) -> *mut c_void;
+
+/*
+    #[link_name = "NeonSys_Class_SetCallHandler"]
+    pub fn set_call_handler(ft: Local, isolate: *mut Isolate, callback: *mut c_void, construct_kernel: *mut c_void);
+*/
+
+}

--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -1,22 +1,37 @@
-use std::os::raw::c_void;
+use std::os::raw::{c_void, c_char};
 use raw::{FunctionCallbackInfo, Isolate, Local};
 
 extern "system" {
 
-    #[link_name = "NeonSys_Class_ForConstructor"]
-    pub fn for_constructor(info: &FunctionCallbackInfo, out: &mut Local);
+    #[link_name = "NeonSys_Class_GetClassMap"]
+    pub fn get_class_map(isolate: *mut Isolate) -> *mut c_void;
 
-    #[link_name = "NeonSys_Class_ForMethod"]
-    pub fn for_method(info: &FunctionCallbackInfo, out: &mut Local);
+    #[link_name = "NeonSys_Class_SetClassMap"]
+    pub fn set_class_map(isolate: *mut Isolate, map: *mut c_void, free_map: *mut c_void);
 
-    #[link_name = "NeonSys_Class_Create"]
-    pub fn create(out: &mut Local, isolate: *mut Isolate, callback: *mut c_void, construct_kernel: *mut c_void) -> bool;
+    #[link_name = "NeonSys_Class_CreateBase"]
+    pub fn create_base(isolate: *mut Isolate,
+                       allocate_callback: *mut c_void, allocate_kernel: *mut c_void,
+                       construct_callback: *mut c_void, construct_kernel: *mut c_void,
+                       call_callback: *mut c_void, call_kernel: *mut c_void) -> *mut c_void;
 
-    #[link_name = "NeonSys_Class_GetConstructorKernel"]
-    pub fn get_constructor_kernel(obj: Local) -> *mut c_void;
+    #[link_name = "NeonSys_Class_SetName"]
+    pub fn set_name(isolate: *mut Isolate, metadata: *mut c_void, name: *const u8, byte_length: u32) -> bool;
 
-    #[link_name = "NeonSys_Class_ExecConstructorKernel"]
-    pub fn exec_constructor_kernel(closure: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), info: &FunctionCallbackInfo, scope: *mut c_void);
+    #[link_name = "NeonSys_Class_AddMethod"]
+    pub fn add_method(isolate: *mut Isolate, metadata: *mut c_void, name: *const u8, byte_length: u32, method: Local) -> bool;
+
+    #[link_name = "NeonSys_Class_MetadataToClass"]
+    pub fn metadata_to_class(out: &mut Local, isolate: *mut Isolate, metadata: *mut c_void);
+
+    #[link_name = "NeonSys_Class_GetAllocateKernel"]
+    pub fn get_allocate_kernel(obj: Local) -> *mut c_void;
+
+    #[link_name = "NeonSys_Class_GetConstructKernel"]
+    pub fn get_construct_kernel(obj: Local) -> *mut c_void;
+
+    #[link_name = "NeonSys_Class_GetCallKernel"]
+    pub fn get_call_kernel(obj: Local) -> *mut c_void;
 
     #[link_name = "NeonSys_Class_Constructor"]
     pub fn constructor(out: &mut Local, ft: Local);
@@ -24,12 +39,10 @@ extern "system" {
     #[link_name = "NeonSys_Class_Check"]
     pub fn check(c: Local, v: Local) -> bool;
 
+    #[link_name = "NeonSys_Class_HasInstance"]
+    pub fn has_instance(metadata: *mut c_void, v: Local) -> bool;
+
     #[link_name = "NeonSys_Class_GetInstanceInternals"]
     pub fn get_instance_internals(obj: Local) -> *mut c_void;
-
-/*
-    #[link_name = "NeonSys_Class_SetCallHandler"]
-    pub fn set_call_handler(ft: Local, isolate: *mut Isolate, callback: *mut c_void, construct_kernel: *mut c_void);
-*/
 
 }

--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -13,7 +13,8 @@ extern "system" {
     pub fn create_base(isolate: *mut Isolate,
                        allocate_callback: *mut c_void, allocate_kernel: *mut c_void,
                        construct_callback: *mut c_void, construct_kernel: *mut c_void,
-                       call_callback: *mut c_void, call_kernel: *mut c_void) -> *mut c_void;
+                       call_callback: *mut c_void, call_kernel: *mut c_void,
+                       drop: extern "C" fn(*mut c_void)) -> *mut c_void;
 
     #[link_name = "NeonSys_Class_SetName"]
     pub fn set_name(isolate: *mut Isolate, metadata: *mut c_void, name: *const u8, byte_length: u32) -> bool;

--- a/crates/neon-sys/src/class.rs
+++ b/crates/neon-sys/src/class.rs
@@ -1,5 +1,5 @@
-use std::os::raw::{c_void, c_char};
-use raw::{FunctionCallbackInfo, Isolate, Local};
+use std::os::raw::c_void;
+use raw::{Isolate, Local};
 
 extern "system" {
 

--- a/crates/neon-sys/src/error.rs
+++ b/crates/neon-sys/src/error.rs
@@ -3,12 +3,15 @@ use raw::Local;
 extern "system" {
 
     #[link_name = "NeonSys_Error_NewTypeError"]
-    pub fn new_type_error(out: &mut Local, msg: *const u8) -> bool;
+    pub fn new_type_error(out: &mut Local, msg: Local) -> bool;
+
+    #[link_name = "NeonSys_Error_CStringToTypeError"]
+    pub fn cstring_to_type_error(out: &mut Local, msg: *const u8) -> bool;
 
     #[link_name = "NeonSys_Error_Throw"]
     pub fn throw(val: Local);
 
-    #[link_name = "NeonSys_Error_ThrowTypeError"]
-    pub fn throw_type_error(msg: *const u8);
+    #[link_name = "NeonSys_Error_ThrowTypeErrorFromCString"]
+    pub fn throw_type_error_from_cstring(msg: *const u8);
 
 }

--- a/crates/neon-sys/src/fun.rs
+++ b/crates/neon-sys/src/fun.rs
@@ -6,8 +6,8 @@ extern "system" {
     #[link_name = "NeonSys_Fun_New"]
     pub fn new(out: &mut Local, isolate: *mut c_void, callback: *mut c_void, kernel: *mut c_void) -> bool;
 
-    #[link_name = "NeonSys_Fun_ExecBody"]
-    pub fn exec_body(closure: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), info: &FunctionCallbackInfo, scope: *mut c_void);
+    #[link_name = "NeonSys_Fun_ExecKernel"]
+    pub fn exec_kernel(kernel: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), info: &FunctionCallbackInfo, scope: *mut c_void);
 
     #[link_name = "NeonSys_Fun_GetKernel"]
     pub fn get_kernel(obj: Local) -> *mut c_void;

--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -13,3 +13,4 @@ pub mod module;
 pub mod mem;
 pub mod fun;
 pub mod convert;
+pub mod class;

--- a/crates/neon-sys/src/module.rs
+++ b/crates/neon-sys/src/module.rs
@@ -3,7 +3,7 @@ use raw::Local;
 
 extern "system" {
 
-    #[link_name = "NeonSys_Module_ExecBody"]
-    pub fn exec_body(kernel: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), exports: Local, scope: *mut c_void);
+    #[link_name = "NeonSys_Module_ExecKernel"]
+    pub fn exec_kernel(kernel: *mut c_void, callback: extern fn(*mut c_void, *mut c_void, *mut c_void), exports: Local, scope: *mut c_void);
 
 }

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include "node.h"
 #include "neon.h"
+#include "neon_string.h"
 #include "neon_class_metadata.h"
 
 extern "C" void NeonSys_Call_SetReturn(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::Value> value) {
@@ -311,7 +312,19 @@ extern "C" bool NeonSys_Class_SetName(v8::Isolate *isolate, void *metadata_point
     return false;
   }
   ft->SetClassName(class_name);
+  metadata->SetName(neon::Slice(name, byte_length));
   return true;
+}
+
+extern "C" void NeonSys_Class_ThrowCallError(v8::Isolate *isolate, void *metadata_pointer) {
+  neon::ClassMetadata *metadata = static_cast<neon::ClassMetadata *>(metadata_pointer);
+  Nan::ThrowTypeError(metadata->GetCallError().ToJsString(isolate, "constructor called without new."));
+}
+
+
+extern "C" void NeonSys_Class_ThrowThisError(v8::Isolate *isolate, void *metadata_pointer) {
+  neon::ClassMetadata *metadata = static_cast<neon::ClassMetadata *>(metadata_pointer);
+  Nan::ThrowTypeError(metadata->GetThisError().ToJsString(isolate, "this is not an object of the expected type."));
 }
 
 extern "C" bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata_pointer, const char *name, uint32_t byte_length, v8::Local<v8::Function> method) {
@@ -409,12 +422,17 @@ extern "C" void NeonSys_Error_Throw(v8::Local<v8::Value> val) {
   Nan::ThrowError(val);
 }
 
-extern "C" bool NeonSys_Error_NewTypeError(v8::Local<v8::Value> *out, const char *msg) {
+extern "C" bool NeonSys_Error_NewTypeError(v8::Local<v8::Value> *out, v8::Local<v8::String> msg) {
   *out = Nan::TypeError(msg);
   return true;
 }
 
-extern "C" void NeonSys_Error_ThrowTypeError(const char *msg) {
+extern "C" bool NeonSys_Error_CStringToTypeError(v8::Local<v8::Value> *out, const char *msg) {
+  *out = Nan::TypeError(msg);
+  return true;
+}
+
+extern "C" void NeonSys_Error_ThrowTypeErrorFromCString(const char *msg) {
   Nan::ThrowTypeError(msg);
 }
 

--- a/crates/neon-sys/src/neon.h
+++ b/crates/neon-sys/src/neon.h
@@ -87,17 +87,18 @@ extern "C" {
   void NeonSys_Class_ForConstructor(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::FunctionTemplate> *out);
   void NeonSys_Class_ForMethod(v8::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::FunctionTemplate> *out);
 
-  typedef void (*NeonSys_FreeCallback)(void *);
+  typedef void (*NeonSys_DropCallback)(void *);
 
   void *NeonSys_Class_GetClassMap(v8::Isolate *isolate);
-  void NeonSys_Class_SetClassMap(v8::Isolate *isolate, void *map, NeonSys_FreeCallback free_map);
+  void NeonSys_Class_SetClassMap(v8::Isolate *isolate, void *map, NeonSys_DropCallback free_map);
   void *NeonSys_Class_CreateBase(v8::Isolate *isolate,
                                  NeonSys_AllocateCallback allocate_callback,
                                  void *allocate_kernel,
                                  NeonSys_ConstructCallback construct_callback,
                                  void *construct_kernel,
                                  v8::FunctionCallback call_callback,
-                                 void *call_kernel);
+                                 void *call_kernel,
+                                 NeonSys_DropCallback drop);
   void *NeonSys_Class_GetCallKernel(v8::Local<v8::External> wrapper);
   void *NeonSys_Class_GetConstructKernel(v8::Local<v8::External> wrapper);
   void *NeonSys_Class_GetAllocateKernel(v8::Local<v8::External> wrapper);

--- a/crates/neon-sys/src/neon.h
+++ b/crates/neon-sys/src/neon.h
@@ -106,6 +106,7 @@ extern "C" {
   bool NeonSys_Class_Check(v8::Local<v8::FunctionTemplate> ft, v8::Local<v8::Value> v);
   bool NeonSys_Class_HasInstance(void *metadata, v8::Local<v8::Value> v);
   bool NeonSys_Class_SetName(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length);
+  void NeonSys_Class_ThrowThisError(v8::Isolate *isolate, void *metadata_pointer);
   bool NeonSys_Class_AddMethod(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length, v8::Local<v8::Function> method);
   void NeonSys_Class_MetadataToClass(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, void *metadata);
   void *NeonSys_Class_GetInstanceInternals(v8::Local<v8::Object> obj);
@@ -125,9 +126,10 @@ extern "C" {
   bool NeonSys_Tag_IsBuffer(v8::Local<v8::Value> obj);
   bool NeonSys_Tag_IsTypeError(v8::Local<v8::Value> val);
 
-  bool NeonSys_Error_NewTypeError(v8::Local<v8::Value> *out, const char *msg);
+  bool NeonSys_Error_NewTypeError(v8::Local<v8::Value> *out, v8::Local<v8::String> msg);
+  bool NeonSys_Error_CStringToTypeError(v8::Local<v8::Value> *out, const char *msg);
   void NeonSys_Error_Throw(v8::Local<v8::Value> val);
-  void NeonSys_Error_ThrowTypeError(const char *msg);
+  void NeonSys_Error_ThrowTypeErrorFromCString(const char *msg);
 
   bool NeonSys_Mem_SameHandle(v8::Local<v8::Value> v1, v8::Local<v8::Value> v2);
 }

--- a/crates/neon-sys/src/neon.h
+++ b/crates/neon-sys/src/neon.h
@@ -102,7 +102,7 @@ extern "C" {
   void *NeonSys_Class_GetCallKernel(v8::Local<v8::External> wrapper);
   void *NeonSys_Class_GetConstructKernel(v8::Local<v8::External> wrapper);
   void *NeonSys_Class_GetAllocateKernel(v8::Local<v8::External> wrapper);
-  void NeonSys_Class_Constructor(v8::Local<v8::Function> *out, v8::Local<v8::FunctionTemplate> ft);
+  bool NeonSys_Class_Constructor(v8::Local<v8::Function> *out, v8::Local<v8::FunctionTemplate> ft);
   bool NeonSys_Class_Check(v8::Local<v8::FunctionTemplate> ft, v8::Local<v8::Value> v);
   bool NeonSys_Class_HasInstance(void *metadata, v8::Local<v8::Value> v);
   bool NeonSys_Class_SetName(v8::Isolate *isolate, void *metadata, const char *name, uint32_t byte_length);

--- a/crates/neon-sys/src/neon.h
+++ b/crates/neon-sys/src/neon.h
@@ -77,6 +77,15 @@ extern "C" {
   void NeonSys_Fun_ExecBody(void *closure, NeonSys_RootScopeCallback callback, Nan::FunctionCallbackInfo<v8::Value> *info, void *scope);
   void *NeonSys_Fun_GetKernel(v8::Local<v8::Object> obj);
 
+  void NeonSys_Class_ForConstructor(Nan::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::FunctionTemplate> *out);
+  void NeonSys_Class_ForMethod(Nan::FunctionCallbackInfo<v8::Value> *info, v8::Local<v8::FunctionTemplate> *out);
+  bool NeonSys_Class_Create(v8::Local<v8::FunctionTemplate> *out, v8::Isolate *isolate, v8::FunctionCallback callback, void *construct_kernel);
+  void *NeonSys_Class_GetConstructorKernel(v8::Local<v8::External> wrapper);
+  void NeonSys_Class_ExecConstructorKernel(void *closure, NeonSys_RootScopeCallback callback, Nan::FunctionCallbackInfo<v8::Value> *info, void *scope);
+  void NeonSys_Class_Constructor(v8::Local<v8::Function> *out, v8::Local<v8::FunctionTemplate> ft);
+  bool NeonSys_Class_Check(v8::Local<v8::FunctionTemplate> ft, v8::Local<v8::Value> v);
+  void *NeonSys_Class_GetInstanceInternals(v8::Local<v8::Object> obj);
+
   void NeonSys_Module_ExecBody(void *kernel, NeonSys_ModuleScopeCallback callback, v8::Local<v8::Object> exports, void *scope);
 
   tag_t NeonSys_Tag_Of(v8::Local<v8::Value> val);

--- a/crates/neon-sys/src/neon_class_metadata.h
+++ b/crates/neon-sys/src/neon_class_metadata.h
@@ -3,20 +3,61 @@
 
 #include <stdint.h>
 #include "v8.h"
-
-// FIXME: error propagation
-typedef void *(*NeonSys_CreateInternalsCallback)(int32_t argc, v8::Local<v8::Value> argv[]);
-
-// FIXME: is bool the right way to do error propagation?
-typedef bool(*NeonSys_ConstructorKernelCallback)(v8::Local<v8::Object> self, int32_t argc, v8::Local<v8::Value> argv[]);
+#include "neon.h"
 
 
-class NeonClassConstructorMetadata {
+// Currently, Node only ever has one isolate so we could get away with storing
+// Neon metadata in a global variable. But when workers land in Node, they will
+// each have a separate isolate.
+//
+// See: https://github.com/nodejs/node/pull/2133
+//
+// So instead we have to store per-isolate metadata in one of the isolate's
+// extensible data slots.
+//
+// Slots 0 and 1 appear to be reserved by Chrome, and slot 3 is reserved by Node.
+// That apparently leaves only slot 2 available for storing Neon metadata.
+//
+// See: https://github.com/nodejs/node/blob/master/src/env.h#L33-L39
+//
+// If this causes clashes with some other consumer of V8 in the future, we try
+// proposing to Node to make node::Environment extensible instead.
+
+#define NEON_ISOLATE_SLOT 2
+
+
+namespace neon {
+
+class ClassMapHolder {
+public:
+  ClassMapHolder(void *map, NeonSys_FreeCallback free_map)
+    : map_(map), free_map_(free_map)
+  {
+  }
+
+  ~ClassMapHolder() {
+    free_map_(map_);
+    map_ = nullptr;
+  }
+
+  void *GetMap() {
+    return map_;
+  }
+
+private:
+  void *map_;
+  NeonSys_FreeCallback free_map_;
+};
+
+
+class ClassMetadata {
 public:
 
-  NeonClassConstructorMetadata(NeonSys_ConstructorKernelCallback kernel) {
-    is_allocating_ = false;
-    kernel_ = kernel;
+  ClassMetadata(NeonSys_ConstructCallback construct_callback, void *construct_kernel, v8::FunctionCallback call_callback, void *call_kernel) {
+    construct_callback_ = construct_callback;
+    construct_kernel_ = construct_kernel;
+    call_callback_ = call_callback;
+    call_kernel_ = call_kernel;
   }
 
   void SetTemplate(v8::Isolate *isolate, v8::Local<v8::FunctionTemplate> t) {
@@ -28,38 +69,36 @@ public:
     return v8::Local<v8::FunctionTemplate>::New(isolate, template_);
   }
 
-  // FIXME: is bool the right way to propagate errors?
-  virtual bool construct(v8::Local<v8::Object> self, int argc, v8::Local<v8::Value> argv[]) = 0;
+  virtual bool construct(const v8::FunctionCallbackInfo<v8::Value>& info) = 0;
 
-  NeonSys_ConstructorKernelCallback GetKernel() {
-    return kernel_;
+  // FIXME(PR): save a flag on `this` if it fails?
+  void call(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    call_callback_(info);
   }
 
-  // FIXME: return MaybeLocal
-  v8::Local<v8::Object> allocate(v8::Isolate *isolate) {
-    v8::Local<v8::Context> cx = isolate->GetCurrentContext();
-    v8::Local<v8::Function> f = GetTemplate(isolate)->GetFunction();
-    is_allocating_ = true;
-    // FIXME: error propagation
-    v8::Local<v8::Object> instance = f->NewInstance(cx).ToLocalChecked();
-    is_allocating_ = false;
-    return instance;
+  void *GetCallKernel() {
+    return call_kernel_;
+  }
+
+  void *GetConstructKernel() {
+    return construct_kernel_;
   }
 
 protected:
 
-  virtual ~NeonClassConstructorMetadata() {
+  virtual ~ClassMetadata() {
     template_.Reset();
   }
 
-  bool is_allocating_;
-
-  NeonSys_ConstructorKernelCallback kernel_;
+  NeonSys_ConstructCallback construct_callback_;
+  void *construct_kernel_;
+  v8::FunctionCallback call_callback_;
+  void *call_kernel_;
 
 private:
 
-  static void Finalize(const v8::WeakCallbackInfo<NeonClassConstructorMetadata>& data) {
-    NeonClassConstructorMetadata *metadata = data.GetParameter();
+  static void Finalize(const v8::WeakCallbackInfo<ClassMetadata>& data) {
+    ClassMetadata *metadata = data.GetParameter();
     delete metadata;
   }
 
@@ -67,43 +106,44 @@ private:
   
 };
 
-class NeonBaseClassConstructorMetadata: public NeonClassConstructorMetadata {
+
+class BaseClassMetadata: public ClassMetadata {
 public:
 
-  NeonBaseClassConstructorMetadata(NeonSys_ConstructorKernelCallback kernel, NeonSys_CreateInternalsCallback cb)
-    : NeonClassConstructorMetadata(kernel)
+  BaseClassMetadata(NeonSys_ConstructCallback construct_callback,
+                    void *construct_kernel,
+                    v8::FunctionCallback call_callback,
+                    void *call_kernel,
+                    NeonSys_AllocateCallback allocate_callback,
+                    void *allocate_kernel)
+    : ClassMetadata(construct_callback, construct_kernel, call_callback, call_kernel)
   {
-    create_internals_callback_ = cb;
+    allocate_callback_ = allocate_callback;
+    allocate_kernel_ = allocate_kernel;
   }
 
-  virtual bool construct(v8::Local<v8::Object> self, int argc, v8::Local<v8::Value> argv[]) {
-    void *internals = create_internals_callback_(argc, argv);
-    self->SetAlignedPointerInInternalField(0, internals);
-    return kernel_(self, argc, argv);
+  void *GetAllocateKernel() {
+    return allocate_kernel_;
+  }
+
+  // FIXME(PR): instead of returning bool, save a flag on `this`
+  virtual bool construct(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    void *internals = allocate_callback_(&info);
+    if (!internals) {
+      return false;
+    }
+    info.This()->SetAlignedPointerInInternalField(0, internals);
+    return !construct_kernel_ || construct_callback_(&info);
   }
 
 private:
 
-  NeonSys_CreateInternalsCallback create_internals_callback_;
+  NeonSys_AllocateCallback allocate_callback_;
+  void *allocate_kernel_;
 };
 
-class NeonDerivedClassConstructorMetadata: public NeonClassConstructorMetadata {
-public:
+// TODO: subclasses: class DerivedClassMetadata: public ClassMetadata { ... };
 
-  NeonDerivedClassConstructorMetadata(NeonSys_ConstructorKernelCallback kernel, NeonClassConstructorMetadata *super_metadata)
-    : NeonClassConstructorMetadata(kernel)
-  {
-    super_metadata_ = super_metadata;
-  }
-
-  virtual bool construct(v8::Local<v8::Object> self, int argc, v8::Local<v8::Value> argv[]) {
-    return super_metadata_->construct(self, argc, argv) &&
-           kernel_(self, argc, argv);
-  }
-
-private:
-
-  NeonClassConstructorMetadata *super_metadata_;
-};
+}; // end namespace neon
 
 #endif

--- a/crates/neon-sys/src/neon_class_metadata.h
+++ b/crates/neon-sys/src/neon_class_metadata.h
@@ -1,0 +1,109 @@
+#ifndef NEON_CLASS_METADATA_H_
+#define NEON_CLASS_METADATA_H_
+
+#include <stdint.h>
+#include "v8.h"
+
+// FIXME: error propagation
+typedef void *(*NeonSys_CreateInternalsCallback)(int32_t argc, v8::Local<v8::Value> argv[]);
+
+// FIXME: is bool the right way to do error propagation?
+typedef bool(*NeonSys_ConstructorKernelCallback)(v8::Local<v8::Object> self, int32_t argc, v8::Local<v8::Value> argv[]);
+
+
+class NeonClassConstructorMetadata {
+public:
+
+  NeonClassConstructorMetadata(NeonSys_ConstructorKernelCallback kernel) {
+    is_allocating_ = false;
+    kernel_ = kernel;
+  }
+
+  void SetTemplate(v8::Isolate *isolate, v8::Local<v8::FunctionTemplate> t) {
+    template_.Reset(isolate, t);
+    template_.SetWeak(this, Finalize, v8::WeakCallbackType::kParameter);
+  }
+
+  v8::Local<v8::FunctionTemplate> GetTemplate(v8::Isolate *isolate) {
+    return v8::Local<v8::FunctionTemplate>::New(isolate, template_);
+  }
+
+  // FIXME: is bool the right way to propagate errors?
+  virtual bool construct(v8::Local<v8::Object> self, int argc, v8::Local<v8::Value> argv[]) = 0;
+
+  NeonSys_ConstructorKernelCallback GetKernel() {
+    return kernel_;
+  }
+
+  // FIXME: return MaybeLocal
+  v8::Local<v8::Object> allocate(v8::Isolate *isolate) {
+    v8::Local<v8::Context> cx = isolate->GetCurrentContext();
+    v8::Local<v8::Function> f = GetTemplate(isolate)->GetFunction();
+    is_allocating_ = true;
+    // FIXME: error propagation
+    v8::Local<v8::Object> instance = f->NewInstance(cx).ToLocalChecked();
+    is_allocating_ = false;
+    return instance;
+  }
+
+protected:
+
+  virtual ~NeonClassConstructorMetadata() {
+    template_.Reset();
+  }
+
+  bool is_allocating_;
+
+  NeonSys_ConstructorKernelCallback kernel_;
+
+private:
+
+  static void Finalize(const v8::WeakCallbackInfo<NeonClassConstructorMetadata>& data) {
+    NeonClassConstructorMetadata *metadata = data.GetParameter();
+    delete metadata;
+  }
+
+  v8::Global<v8::FunctionTemplate> template_;
+  
+};
+
+class NeonBaseClassConstructorMetadata: public NeonClassConstructorMetadata {
+public:
+
+  NeonBaseClassConstructorMetadata(NeonSys_ConstructorKernelCallback kernel, NeonSys_CreateInternalsCallback cb)
+    : NeonClassConstructorMetadata(kernel)
+  {
+    create_internals_callback_ = cb;
+  }
+
+  virtual bool construct(v8::Local<v8::Object> self, int argc, v8::Local<v8::Value> argv[]) {
+    void *internals = create_internals_callback_(argc, argv);
+    self->SetAlignedPointerInInternalField(0, internals);
+    return kernel_(self, argc, argv);
+  }
+
+private:
+
+  NeonSys_CreateInternalsCallback create_internals_callback_;
+};
+
+class NeonDerivedClassConstructorMetadata: public NeonClassConstructorMetadata {
+public:
+
+  NeonDerivedClassConstructorMetadata(NeonSys_ConstructorKernelCallback kernel, NeonClassConstructorMetadata *super_metadata)
+    : NeonClassConstructorMetadata(kernel)
+  {
+    super_metadata_ = super_metadata;
+  }
+
+  virtual bool construct(v8::Local<v8::Object> self, int argc, v8::Local<v8::Value> argv[]) {
+    return super_metadata_->construct(self, argc, argv) &&
+           kernel_(self, argc, argv);
+  }
+
+private:
+
+  NeonClassConstructorMetadata *super_metadata_;
+};
+
+#endif

--- a/crates/neon-sys/src/neon_string.h
+++ b/crates/neon-sys/src/neon_string.h
@@ -1,0 +1,98 @@
+#ifndef NEON_STRING_H_
+#define NEON_STRING_H_
+
+namespace neon {
+
+class Slice {
+public:
+  Slice(const char *buffer, uint32_t length)
+    : buffer_(buffer), length_(length)
+  {
+  }
+
+  v8::Local<v8::String> ToJsString(v8::Isolate *isolate, const char *fallback) {
+    v8::MaybeLocal<v8::String> maybe;
+    v8::Local<v8::String> result;
+
+    maybe = v8::String::NewFromUtf8(isolate, buffer_, v8::NewStringType::kNormal, length_);
+    if (maybe.ToLocal(&result)) {
+      return result;
+    }
+
+    maybe = v8::String::NewFromOneByte(isolate, (const uint8_t *)fallback, v8::NewStringType::kNormal);
+    if (maybe.ToLocal(&result)) {
+      return result;
+    }
+
+    maybe = v8::String::NewFromOneByte(isolate, (const uint8_t *)"?", v8::NewStringType::kNormal);
+    maybe.ToLocal(&result);
+    return result;
+  }
+
+  const char *GetBuffer() {
+    return buffer_;
+  }
+
+  uint32_t GetLength() {
+    return length_;
+  }
+
+private:
+
+  const char *buffer_;
+  uint32_t length_;
+};
+
+
+class String {
+public:
+  String(uint32_t length) {
+    length_ = length;
+    buffer_ = new char [length];
+    cursor_ = 0;
+  }
+
+  ~String() {
+    delete buffer_;
+    buffer_ = nullptr;
+    length_ = 0;
+  }
+
+  Slice Borrow() {
+    return Slice(buffer_, length_);
+  }
+
+  char *GetBuffer() {
+    return buffer_;
+  }
+
+  uint32_t GetLength() {
+    return length_;
+  }
+
+  String& operator<<(const char *s) {
+    while (*s) {
+      buffer_[cursor_] = *s;
+      cursor_++;
+      s++;
+    }
+    return *this;
+  }
+
+  String& operator<<(Slice s) {
+    uint32_t length = s.GetLength();
+    memcpy(buffer_ + cursor_, s.GetBuffer(), length);
+    cursor_ += length;
+    return *this;
+  }
+
+private:
+
+  char *buffer_;
+  uint32_t length_;
+  uint32_t cursor_;
+};
+
+}; // end namespace neon
+
+#endif

--- a/crates/neon-sys/src/raw.rs
+++ b/crates/neon-sys/src/raw.rs
@@ -1,7 +1,6 @@
 use std::os::raw::c_void;
 
 #[repr(C)]
-#[allow(raw_pointer_derive)]
 #[derive(Clone, Copy)]
 pub struct Local {
     pub handle: *mut c_void

--- a/src/internal/js/binary.rs
+++ b/src/internal/js/binary.rs
@@ -33,6 +33,9 @@ impl Value for JsBuffer { }
 
 impl Object for JsBuffer { }
 
+// FIXME: I believe this is unsafe. I think the Lock API needs to
+// tighten the lifetime of the exposed internals not to outlive the
+// lock.
 impl<'a> Lock for Handle<'a, JsBuffer> {
     type Internals = Buf<'a>;
 

--- a/src/internal/js/binary.rs
+++ b/src/internal/js/binary.rs
@@ -1,6 +1,6 @@
 use vm::VmResult;
 use internal::js::{Value, ValueInternal, Object, build};
-use internal::mem::Handle;
+use internal::mem::{Handle, Managed};
 use internal::vm::{Lock, LockState};
 use scope::Scope;
 use neon_sys;
@@ -17,11 +17,13 @@ impl JsBuffer {
     }
 }
 
-impl ValueInternal for JsBuffer {
+impl Managed for JsBuffer {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsBuffer(h) }
+}
 
+impl ValueInternal for JsBuffer {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_buffer(other.to_raw()) }
     }

--- a/src/internal/js/binary.rs
+++ b/src/internal/js/binary.rs
@@ -33,7 +33,7 @@ impl Value for JsBuffer { }
 
 impl Object for JsBuffer { }
 
-// FIXME: I believe this is unsafe. I think the Lock API needs to
+// TODO: I believe this is unsafe. I think the Lock API needs to
 // tighten the lifetime of the exposed internals not to outlive the
 // lock.
 impl<'a> Lock for Handle<'a, JsBuffer> {

--- a/src/internal/js/class.rs
+++ b/src/internal/js/class.rs
@@ -362,19 +362,12 @@ impl<T: Class> JsClass<T> {
         }
     }
 
-    /*
-    // FIXME(PR): implement this
-    pub fn new<'a, U: Scope<'a>>(&self, _: &mut U) -> JsResult<'a, T> {
-        unimplemented!()
-    }
-    */
-
     pub fn constructor<'a, U: Scope<'a>>(&self, _: &mut U) -> JsResult<'a, JsFunction> {
-        unsafe {
-            let mut local: raw::Local = mem::zeroed();
-            neon_sys::class::constructor(&mut local, self.to_raw());
-            Ok(Handle::new(JsFunction::from_raw(local)))
-        }
+        build(|out| {
+            unsafe {
+                neon_sys::class::constructor(out, self.to_raw())
+            }
+        })
     }
 }
 

--- a/src/internal/js/class.rs
+++ b/src/internal/js/class.rs
@@ -1,15 +1,14 @@
-use std::ffi::CString;
 use std::any::{Any, TypeId};
 use std::mem;
-use std::marker::{Sized, PhantomData};
+use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::ptr::null_mut;
 use neon_sys;
 use neon_sys::raw;
 use internal::mem::{Handle, HandleInternal, Managed};
 use internal::scope::{Scope, ScopeInternal};
-use internal::vm::{Isolate, IsolateInternal, JsResult, VmResult, FunctionCall, Call, CallbackInfo, Lock, LockState, Throw, This, Kernel, exec_function_kernel};
-use internal::js::{Value, ValueInternal, JsFunction, JsObject, JsValue, JsUndefined, JsString, build, call_neon_function};
+use internal::vm::{Isolate, IsolateInternal, JsResult, VmResult, FunctionCall, CallbackInfo, Lock, LockState, Throw, This, Kernel, exec_function_kernel};
+use internal::js::{Value, ValueInternal, JsFunction, JsObject, JsValue, JsUndefined, build};
 use internal::js::error::JsTypeError;
 
 #[repr(C)]
@@ -293,19 +292,6 @@ pub trait ClassInternal: Class {
 }
 
 impl<T: Class> ClassInternal for T { }
-
-fn strip_null_bytes(s: &str) -> String {
-    s.chars()
-     .filter(|c| *c != '\0')
-     .collect()
-}
-
-fn method_name(s: &str) -> VmResult<CString> {
-    match CString::new(s) {
-        Ok(cs) => Ok(cs),
-        Err(_) => JsTypeError::throw(&format!("illegal null byte in method name {}", strip_null_bytes(s))[..])
-    }
-}
 
 impl<T: Class> ValueInternal for T {
     fn is_typeof<Other: Value>(value: Other) -> bool {

--- a/src/internal/js/class.rs
+++ b/src/internal/js/class.rs
@@ -1,0 +1,163 @@
+use std::mem;
+use std::marker::PhantomData;
+use std::os::raw::c_void;
+use std::ptr::null_mut;
+use neon_sys;
+use neon_sys::raw;
+use internal::mem::{Handle, HandleInternal, Managed};
+use internal::scope::{Scope, RootScope, RootScopeInternal};
+use internal::vm::{JsResult, ConstructorCall, MethodCall, CallbackInfo, Lock, LockState, exec_constructor_kernel};
+use internal::js::{Value, JsFunction, build};
+use internal::js::error::JsTypeError;
+
+pub type Constructor<T> = fn(ConstructorCall<T>) -> JsResult<T>;
+pub type Method<T> = fn(MethodCall<T>) -> JsResult<T>;
+
+pub struct ClassDescriptor<'a, T: Class> {
+    name: Option<&'a str>,
+    call: Option<Constructor<T>>,
+    construct: Option<Constructor<T>>,
+    methods: Vec<(&'a str, Method<T>)>
+}
+
+impl<'a, T: Class> ClassDescriptor<'a, T> {
+    pub fn name(&mut self, name: &'a str) -> &mut ClassDescriptor<'a, T> {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn call(&mut self, body: Constructor<T>) -> &mut ClassDescriptor<'a, T> {
+        self.call = Some(body);
+        self
+    }
+
+    pub fn construct(&mut self, body: Constructor<T>) -> &mut ClassDescriptor<'a, T> {
+        self.construct = Some(body);
+        self
+    }
+
+    pub fn constructor(&mut self, body: Constructor<T>) -> &mut ClassDescriptor<'a, T> {
+        self.call = Some(body);
+        self.construct = Some(body);
+        self
+    }
+
+    pub fn method(&mut self, name: &'a str, body: Method<T>) -> &mut ClassDescriptor<'a, T> {
+        self.methods.push((name, body));
+        self
+    }
+
+    pub fn create<'b, U: Scope<'b>>(self, scope: &mut U) -> JsResult<'b, JsClass<T>> {
+        build(|out| {
+            unsafe {
+                let isolate: *mut c_void = mem::transmute(scope.isolate());
+                let callback: extern "C" fn(&CallbackInfo) = call_neon_constructor::<T>;
+                let callback: *mut c_void = mem::transmute(callback);
+                let construct_kernel: *mut c_void = match self.construct {
+                    Some(f) => mem::transmute(f),
+                    None => null_mut()
+                };
+                // FIXME: need a v8try! macro for this pattern
+                if !neon_sys::class::create(out, isolate, callback, construct_kernel) {
+                    return false;
+                }
+                // FIXME: implement these
+                /*
+                if let Some(f) = self.call {
+                    if !neon_sys::class::set_call_handler(*out, isolate, callback, mem::transmute(f)) {
+                        return false;
+                    }
+                }
+                if let Some(name) = self.name {
+                    if !neon_sys::class::set_name(out, name) {
+                        return false;
+                    }
+                }
+                for (name, method) in methods {
+                    // ...
+                }
+                 */
+                // FIXME: neon_sys::class::finish(*out) to force the instantiation and disallow further modifications
+                true
+            }
+        })
+    }
+}
+
+extern "C" fn call_neon_constructor<T: Class>(info: &CallbackInfo) {
+    let mut scope = RootScope::new(unsafe { mem::transmute(neon_sys::call::get_isolate(mem::transmute(info))) });
+    exec_constructor_kernel(info, &mut scope, |call| {
+        let data = info.data();
+        let kernel: Constructor<T> = unsafe { mem::transmute(neon_sys::class::get_constructor_kernel(data.to_raw())) };
+        if let Ok(value) = kernel(call) {
+            info.set_return(value);
+        }
+    });
+}
+
+pub trait Class: Value {
+    type Internals;
+
+    fn class<'a>() -> ClassDescriptor<'a, Self> {
+        ClassDescriptor {
+            name: None,
+            call: None,
+            construct: None,
+            methods: Vec::new()
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct JsClass<T: Class> {
+    handle: raw::Local,
+    phantom: PhantomData<T>
+}
+
+impl<T: Class> JsClass<T> {
+    pub fn check<U: Value>(&self, v: Handle<U>) -> JsResult<T> {
+        let local = v.to_raw();
+        if unsafe { neon_sys::class::check(self.to_raw(), local) } {
+            Ok(Handle::new(T::from_raw(local)))
+        } else {
+            // FIXME: custom error message based on class name
+            JsTypeError::throw("failed class check")
+        }
+    }
+
+    pub fn new<'a, U: Scope<'a>>(&self, _: &mut U, internals: T::Internals) -> JsResult<'a, T> {
+        unimplemented!()
+    }
+
+    pub fn constructor<'a, U: Scope<'a>>(&self, _: &mut U) -> JsResult<'a, JsFunction> {
+        unsafe {
+            let mut local: raw::Local = mem::zeroed();
+            neon_sys::class::constructor(&mut local, self.to_raw());
+            Ok(Handle::new(JsFunction::from_raw(local)))
+        }
+    }
+}
+
+// FIXME: I believe this is unsafe. I think the Lock API needs to
+// tighten the lifetime of the exposed internals not to outlive the
+// lock.
+impl<'a, T: Class> Lock for Handle<'a, T> {
+    type Internals = &'a mut T::Internals;
+
+    unsafe fn expose(self, _: &mut LockState) -> Self::Internals {
+        let ptr: *mut c_void = neon_sys::class::get_instance_internals(self.to_raw());
+        mem::transmute(ptr)
+    }
+}
+
+impl<T: Class> Managed for JsClass<T> {
+    fn to_raw(self) -> raw::Local { self.handle }
+
+    fn from_raw(h: raw::Local) -> Self {
+        JsClass {
+            handle: h,
+            phantom: PhantomData
+        }
+    }
+}

--- a/src/internal/js/class.rs
+++ b/src/internal/js/class.rs
@@ -1,112 +1,296 @@
+use std::ffi::CString;
+use std::any::{Any, TypeId};
 use std::mem;
-use std::marker::PhantomData;
+use std::marker::{Sized, PhantomData};
 use std::os::raw::c_void;
 use std::ptr::null_mut;
 use neon_sys;
 use neon_sys::raw;
 use internal::mem::{Handle, HandleInternal, Managed};
-use internal::scope::{Scope, RootScope, RootScopeInternal};
-use internal::vm::{JsResult, ConstructorCall, MethodCall, CallbackInfo, Lock, LockState, exec_constructor_kernel};
-use internal::js::{Value, JsFunction, build};
+use internal::scope::Scope;
+use internal::vm::{Isolate, IsolateInternal, JsResult, VmResult, FunctionCall, Call, CallbackInfo, Lock, LockState, Throw, This, Kernel, exec_function_kernel};
+use internal::js::{Value, ValueInternal, JsFunction, JsObject, JsValue, JsUndefined, build, call_neon_function};
 use internal::js::error::JsTypeError;
 
-pub type Constructor<T> = fn(ConstructorCall<T>) -> JsResult<T>;
-pub type Method<T> = fn(MethodCall<T>) -> JsResult<T>;
+#[repr(C)]
+pub struct MethodKernel<T: Class>(fn(FunctionCall<T>) -> JsResult<JsValue>);
 
-pub struct ClassDescriptor<'a, T: Class> {
-    name: Option<&'a str>,
-    call: Option<Constructor<T>>,
-    construct: Option<Constructor<T>>,
-    methods: Vec<(&'a str, Method<T>)>
+impl<T: Class> MethodKernel<T> {
+    pub fn new(kernel: fn(FunctionCall<T>) -> JsResult<JsValue>) -> Self {
+        MethodKernel(kernel)
+    }
 }
 
-impl<'a, T: Class> ClassDescriptor<'a, T> {
-    pub fn name(&mut self, name: &'a str) -> &mut ClassDescriptor<'a, T> {
-        self.name = Some(name);
-        self
-    }
-
-    pub fn call(&mut self, body: Constructor<T>) -> &mut ClassDescriptor<'a, T> {
-        self.call = Some(body);
-        self
-    }
-
-    pub fn construct(&mut self, body: Constructor<T>) -> &mut ClassDescriptor<'a, T> {
-        self.construct = Some(body);
-        self
-    }
-
-    pub fn constructor(&mut self, body: Constructor<T>) -> &mut ClassDescriptor<'a, T> {
-        self.call = Some(body);
-        self.construct = Some(body);
-        self
-    }
-
-    pub fn method(&mut self, name: &'a str, body: Method<T>) -> &mut ClassDescriptor<'a, T> {
-        self.methods.push((name, body));
-        self
-    }
-
-    pub fn create<'b, U: Scope<'b>>(self, scope: &mut U) -> JsResult<'b, JsClass<T>> {
-        build(|out| {
-            unsafe {
-                let isolate: *mut c_void = mem::transmute(scope.isolate());
-                let callback: extern "C" fn(&CallbackInfo) = call_neon_constructor::<T>;
-                let callback: *mut c_void = mem::transmute(callback);
-                let construct_kernel: *mut c_void = match self.construct {
-                    Some(f) => mem::transmute(f),
-                    None => null_mut()
-                };
-                // FIXME: need a v8try! macro for this pattern
-                if !neon_sys::class::create(out, isolate, callback, construct_kernel) {
-                    return false;
-                }
-                // FIXME: implement these
-                /*
-                if let Some(f) = self.call {
-                    if !neon_sys::class::set_call_handler(*out, isolate, callback, mem::transmute(f)) {
-                        return false;
-                    }
-                }
-                if let Some(name) = self.name {
-                    if !neon_sys::class::set_name(out, name) {
-                        return false;
-                    }
-                }
-                for (name, method) in methods {
-                    // ...
-                }
-                 */
-                // FIXME: neon_sys::class::finish(*out) to force the instantiation and disallow further modifications
-                true
+impl<T: Class> Kernel<()> for MethodKernel<T> {
+    extern "C" fn callback(info: &CallbackInfo) {
+        let mut scope = info.scope();
+        exec_function_kernel(info, &mut scope, |call| {
+            let data = info.data();
+            // FIXME(PR): check that `this` is of the right type or else throw
+            let MethodKernel(kernel) = unsafe { Self::from_raw(data.to_raw()) };
+            if let Ok(value) = kernel(call) {
+                info.set_return(value);
             }
-        })
+        });
+    }
+
+    unsafe fn from_raw(h: raw::Local) -> Self {
+        MethodKernel(mem::transmute(neon_sys::fun::get_kernel(h)))
+    }
+
+    fn as_raw(self) -> *mut c_void {
+        unsafe { mem::transmute(self.0) }
     }
 }
 
-extern "C" fn call_neon_constructor<T: Class>(info: &CallbackInfo) {
-    let mut scope = RootScope::new(unsafe { mem::transmute(neon_sys::call::get_isolate(mem::transmute(info))) });
-    exec_constructor_kernel(info, &mut scope, |call| {
+#[repr(C)]
+pub struct ConstructorCallKernel(fn(FunctionCall<JsValue>) -> JsResult<JsValue>);
+
+impl ConstructorCallKernel {
+    pub fn new(kernel: fn(FunctionCall<JsValue>) -> JsResult<JsValue>) -> Self {
+        ConstructorCallKernel(kernel)
+    }
+
+    extern "C" fn unimplemented(info: &CallbackInfo) {
+        let _ = JsTypeError::throw::<JsUndefined>("constructor requires new");
+    }
+}
+
+impl Kernel<()> for ConstructorCallKernel {
+    extern "C" fn callback(info: &CallbackInfo) {
         let data = info.data();
-        let kernel: Constructor<T> = unsafe { mem::transmute(neon_sys::class::get_constructor_kernel(data.to_raw())) };
+        let mut scope = info.scope();
+        let ConstructorCallKernel(kernel) = unsafe { Self::from_raw(data.to_raw()) };
+        let call = info.as_call(&mut scope);
         if let Ok(value) = kernel(call) {
             info.set_return(value);
         }
-    });
+    }
+
+    unsafe fn from_raw(h: raw::Local) -> Self {
+        ConstructorCallKernel(mem::transmute(neon_sys::class::get_call_kernel(h)))
+    }
+
+    fn as_raw(self) -> *mut c_void {
+        unsafe { mem::transmute(self.0) }
+    }
 }
 
-pub trait Class: Value {
-    type Internals;
+#[repr(C)]
+pub struct AllocateKernel<T: Class>(fn(FunctionCall<JsUndefined>) -> VmResult<T::Internals>);
 
-    fn class<'a>() -> ClassDescriptor<'a, Self> {
+impl<T: Class> AllocateKernel<T> {
+    pub fn new(kernel: fn(FunctionCall<JsUndefined>) -> VmResult<T::Internals>) -> Self {
+        AllocateKernel(kernel)
+    }
+}
+
+impl<T: Class> Kernel<*mut c_void> for AllocateKernel<T> {
+    extern "C" fn callback(info: &CallbackInfo) -> *mut c_void {
+        let data = info.data();
+        let mut scope = info.scope();
+        let AllocateKernel(kernel) = unsafe { Self::from_raw(data.to_raw()) };
+        let call = info.as_call(&mut scope);
+        if let Ok(value) = kernel(call) {
+            let p = Box::into_raw(Box::new(value));
+            // FIXME(PR): attach a destructor to deallocate the internals
+            unsafe { mem::transmute(p) }
+        } else {
+            null_mut()
+        }
+    }
+
+    unsafe fn from_raw(h: raw::Local) -> Self {
+        AllocateKernel(mem::transmute(neon_sys::class::get_allocate_kernel(h)))
+    }
+
+    fn as_raw(self) -> *mut c_void {
+        unsafe { mem::transmute(self.0) }
+    }
+}
+
+#[repr(C)]
+pub struct ConstructKernel<T: Class>(fn(FunctionCall<T>) -> VmResult<Option<Handle<JsObject>>>);
+
+impl<T: Class> ConstructKernel<T> {
+    pub fn new(kernel: fn(FunctionCall<T>) -> VmResult<Option<Handle<JsObject>>>) -> Self {
+        ConstructKernel(kernel)
+    }
+}
+
+impl<T: Class> Kernel<bool> for ConstructKernel<T> {
+    extern "C" fn callback(info: &CallbackInfo) -> bool {
+        let data = info.data();
+        let mut scope = info.scope();
+        let ConstructKernel(kernel) = unsafe { Self::from_raw(data.to_raw()) };
+        let call = info.as_call(&mut scope);
+        match kernel(call) {
+            Ok(None) => true,
+            Ok(Some(obj)) => {
+                info.set_return(obj);
+                true
+            }
+            _ => false
+        }
+    }
+
+    unsafe fn from_raw(h: raw::Local) -> Self {
+        ConstructKernel(mem::transmute(neon_sys::class::get_construct_kernel(h)))
+    }
+
+    fn as_raw(self) -> *mut c_void {
+        unsafe { mem::transmute(self.0) }
+    }
+}
+
+pub struct ClassDescriptor<'a, T: Class> {
+    name: &'a str,
+    allocate: AllocateKernel<T>,
+    call: Option<ConstructorCallKernel>,
+    construct: Option<ConstructKernel<T>>,
+    methods: Vec<(&'a str, MethodKernel<T>)>
+}
+
+impl<'a, T: Class> ClassDescriptor<'a, T> {
+    pub fn new<'b, U: Class>(name: &'b str, allocate: AllocateKernel<U>) -> ClassDescriptor<'b, U> {
         ClassDescriptor {
-            name: None,
+            name: name,
+            allocate: allocate,
             call: None,
             construct: None,
             methods: Vec::new()
         }
     }
+
+    // TODO: fn extend<'b, U: Class<Internals=T::Internals>>(super: Handle<JsClass<U>>, name: &'b str) -> VmResult<ClassDescriptor<'b, U>> { ... }
+
+    pub fn call(mut self, kernel: ConstructorCallKernel) -> Self {
+        self.call = Some(kernel);
+        self
+    }
+
+    pub fn construct(mut self, kernel: ConstructKernel<T>) -> Self {
+        self.construct = Some(kernel);
+        self
+    }
+
+    pub fn method(mut self, name: &'a str, kernel: MethodKernel<T>) -> Self {
+        self.methods.push((name, kernel));
+        self
+    }
 }
+
+pub trait Class: Managed + Any {
+    type Internals;
+
+    fn setup<'a, T: Scope<'a>>(_: &mut T) -> VmResult<ClassDescriptor<'a, Self>>;
+
+    fn class<'a, T: Scope<'a>>(scope: &mut T) -> JsResult<'a, JsClass<Self>> {
+        match Self::metadata(scope).map(|m| unsafe { m.class(scope) }) {
+            None => Self::create(scope),
+            Some(class) => Ok(class)
+        }
+    }
+
+    fn describe<'a>(name: &'a str, allocate: AllocateKernel<Self>) -> ClassDescriptor<'a, Self> {
+        ClassDescriptor::<Self>::new(name, allocate)
+    }
+}
+
+impl<T: Class> This for T {
+    fn as_this(h: raw::Local) -> Self {
+        Self::from_raw(h)
+    }
+}
+
+pub trait ClassInternal: Class {
+    fn metadata<'a, T: Scope<'a>>(scope: &mut T) -> Option<ClassMetadata> {
+        scope.isolate()
+             .class_map()
+             .get(&TypeId::of::<Self>())
+             .map(|m| m.clone())
+    }
+
+    fn create<'a, T: Scope<'a>>(scope: &mut T) -> JsResult<'a, JsClass<Self>> {
+        let descriptor = try!(Self::setup(scope));
+        unsafe {
+            let isolate: *mut c_void = mem::transmute(scope.isolate());
+
+            let (allocate_callback, allocate_kernel) = descriptor.allocate.pair();
+
+            let (construct_callback, construct_kernel) = match descriptor.construct {
+                Some(k) => k.pair(),
+                None    => (null_mut(), null_mut())
+            };
+
+            let (call_callback, call_kernel) = match descriptor.call {
+                Some(k) => k.pair(),
+                None    => (mem::transmute(ConstructorCallKernel::unimplemented), null_mut())
+            };
+
+            let metadata_pointer = neon_sys::class::create_base(isolate,
+                                                                allocate_callback, allocate_kernel,
+                                                                construct_callback, construct_kernel,
+                                                                call_callback, call_kernel);
+
+            if metadata_pointer.is_null() {
+                return Err(Throw);
+            }
+
+            // NOTE: None of the error cases below need to delete the ClassMetadata object, since the
+            //       v8::FunctionTemplate has a finalizer that will delete it.
+
+            let class_name = descriptor.name;
+            if !neon_sys::class::set_name(isolate, metadata_pointer, class_name.as_ptr(), class_name.len() as u32) {
+                return Err(Throw);
+            }
+
+            for (name, method) in descriptor.methods {
+                let method: Handle<JsFunction> = try!(build(|out| {
+                    let (method_callback, method_kernel) = method.pair();
+                    neon_sys::fun::new(out, isolate, method_callback, method_kernel)
+                }));
+                if !neon_sys::class::add_method(isolate, metadata_pointer, name.as_ptr(), name.len() as u32, method.to_raw()) {
+                    return Err(Throw);
+                }
+            }
+
+            let metadata = ClassMetadata {
+                pointer: metadata_pointer
+            };
+
+            scope.isolate().class_map().set(TypeId::of::<Self>(), metadata);
+
+            Ok(metadata.class(scope))
+        }
+    }
+}
+
+impl<T: Class> ClassInternal for T { }
+
+fn method_name(s: &str) -> VmResult<CString> {
+    match CString::new(s) {
+        Ok(cs) => Ok(cs),
+        Err(_) => JsTypeError::throw("invalid method name")
+    }
+}
+
+impl<T: Class> ValueInternal for T {
+    fn is_typeof<Other: Value>(value: Other) -> bool {
+        let mut isolate: Isolate = unsafe {
+            mem::transmute(neon_sys::call::current_isolate())
+        };
+        let map = isolate.class_map();
+        match map.get(&TypeId::of::<T>()) {
+            None => false,
+            Some(ref metadata) => unsafe {
+                metadata.has_instance(value.to_raw())
+            }
+        }
+    }
+}
+
+impl<T: Class> Value for T { }
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -115,20 +299,44 @@ pub struct JsClass<T: Class> {
     phantom: PhantomData<T>
 }
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ClassMetadata {
+    pointer: *mut c_void
+}
+
+impl ClassMetadata {
+    pub unsafe fn class<'a, T: Class, U: Scope<'a>>(&self, scope: &mut U) -> Handle<'a, JsClass<T>> {
+        let mut local: raw::Local = mem::zeroed();
+        neon_sys::class::metadata_to_class(&mut local, mem::transmute(scope.isolate()), self.pointer);
+        Handle::new(JsClass {
+            handle: local,
+            phantom: PhantomData
+        })
+    }
+
+    pub unsafe fn has_instance(&self, value: raw::Local) -> bool {
+        neon_sys::class::has_instance(self.pointer, value)
+    }
+}
+
 impl<T: Class> JsClass<T> {
     pub fn check<U: Value>(&self, v: Handle<U>) -> JsResult<T> {
         let local = v.to_raw();
         if unsafe { neon_sys::class::check(self.to_raw(), local) } {
             Ok(Handle::new(T::from_raw(local)))
         } else {
-            // FIXME: custom error message based on class name
+            // TODO: custom error message based on class name
             JsTypeError::throw("failed class check")
         }
     }
 
-    pub fn new<'a, U: Scope<'a>>(&self, _: &mut U, internals: T::Internals) -> JsResult<'a, T> {
+    /*
+    // FIXME(PR): implement this
+    pub fn new<'a, U: Scope<'a>>(&self, _: &mut U) -> JsResult<'a, T> {
         unimplemented!()
     }
+    */
 
     pub fn constructor<'a, U: Scope<'a>>(&self, _: &mut U) -> JsResult<'a, JsFunction> {
         unsafe {
@@ -139,7 +347,7 @@ impl<T: Class> JsClass<T> {
     }
 }
 
-// FIXME: I believe this is unsafe. I think the Lock API needs to
+// TODO: I believe this is unsafe. I think the Lock API needs to
 // tighten the lifetime of the exposed internals not to outlive the
 // lock.
 impl<'a, T: Class> Lock for Handle<'a, T> {

--- a/src/internal/js/error.rs
+++ b/src/internal/js/error.rs
@@ -6,7 +6,7 @@ use neon_sys::raw;
 
 use internal::vm::{Throw, VmResult};
 use internal::js::{JsObject, Value, ValueInternal, Object, build};
-use internal::mem::Handle;
+use internal::mem::{Handle, Managed};
 use scope::Scope;
 
 pub fn throw<'a, T: Value, U>(v: Handle<'a, T>) -> VmResult<U> {
@@ -20,11 +20,13 @@ pub fn throw<'a, T: Value, U>(v: Handle<'a, T>) -> VmResult<U> {
 #[derive(Clone, Copy)]
 pub struct JsTypeError(raw::Local);
 
-impl ValueInternal for JsTypeError {
+impl Managed for JsTypeError {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsTypeError(h) }
+}
 
+impl ValueInternal for JsTypeError {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_type_error(other.to_raw()) }
     }

--- a/src/internal/js/error.rs
+++ b/src/internal/js/error.rs
@@ -5,7 +5,7 @@ use neon_sys;
 use neon_sys::raw;
 
 use internal::vm::{Throw, VmResult};
-use internal::js::{JsObject, Value, ValueInternal, Object, JsString, ToJsString, build};
+use internal::js::{JsObject, Value, ValueInternal, Object, ToJsString, build};
 use internal::mem::{Handle, Managed};
 use scope::Scope;
 

--- a/src/internal/js/error.rs
+++ b/src/internal/js/error.rs
@@ -41,7 +41,7 @@ fn message(msg: &str) -> CString {
 }
 
 impl JsTypeError {
-    // FIXME: use an overload trait to allow either &str or JsString
+    // TODO: use an overload trait to allow either &str or JsString
     pub fn new<'a, T: Scope<'a>>(_: &mut T, msg: &str) -> VmResult<Handle<'a, JsObject>> {
         let msg = &message(msg);
         build(|out| { unsafe { neon_sys::error::new_type_error(out, mem::transmute(msg.as_ptr())) } })

--- a/src/internal/js/mod.rs
+++ b/src/internal/js/mod.rs
@@ -321,6 +321,25 @@ impl JsString {
     }
 }
 
+pub trait ToJsString {
+    fn to_js_string<'a, T: Scope<'a>>(&self, scope: &mut T) -> Handle<'a, JsString>;
+}
+
+impl<'b> ToJsString for Handle<'b, JsString> {
+    fn to_js_string<'a, T: Scope<'a>>(&self, _: &mut T) -> Handle<'a, JsString> {
+        Handle::new(JsString::from_raw(self.to_raw()))
+    }
+}
+
+impl<'b> ToJsString for &'b str {
+    fn to_js_string<'a, T: Scope<'a>>(&self, scope: &mut T) -> Handle<'a, JsString> {
+        match JsString::new_internal(scope.isolate(), self) {
+            Some(s) => s,
+            None => JsString::new_internal(scope.isolate(), "").unwrap()
+        }
+    }
+}
+
 pub trait JsStringInternal {
     fn new_internal<'a>(isolate: Isolate, val: &str) -> Option<Handle<'a, JsString>>;
 }

--- a/src/internal/js/mod.rs
+++ b/src/internal/js/mod.rs
@@ -6,16 +6,12 @@ use std::os::raw::c_void;
 use neon_sys;
 use neon_sys::raw;
 use neon_sys::tag::Tag;
-use internal::mem::{Handle, HandleInternal};
+use internal::mem::{Handle, HandleInternal, Managed};
 use internal::scope::{Scope, RootScope, RootScopeInternal};
 use internal::vm::{VmResult, Throw, JsResult, Isolate, CallbackInfo, Call, exec_function_body};
 use internal::js::error::JsTypeError;
 
-pub trait ValueInternal: Copy {
-    fn to_raw(self) -> raw::Local;
-
-    fn from_raw(h: raw::Local) -> Self;
-
+pub trait ValueInternal: Managed {
     fn is_typeof<Other: Value>(other: Other) -> bool;
 
     fn downcast<Other: Value>(other: Other) -> Option<Self> {
@@ -92,11 +88,13 @@ pub struct JsValue(raw::Local);
 
 impl Value for JsValue { }
 
-impl ValueInternal for JsValue {
+impl Managed for JsValue {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsValue(h) }
+}
 
+impl ValueInternal for JsValue {
     fn is_typeof<Other: Value>(_: Other) -> bool {
         true
     }
@@ -142,11 +140,13 @@ impl JsUndefined {
 
 impl Value for JsUndefined { }
 
-impl ValueInternal for JsUndefined {
+impl Managed for JsUndefined {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsUndefined(h) }
+}
 
+impl ValueInternal for JsUndefined {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_undefined(other.to_raw()) }
     }
@@ -179,11 +179,13 @@ impl JsNull {
 
 impl Value for JsNull { }
 
-impl ValueInternal for JsNull {
+impl Managed for JsNull {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsNull(h) }
+}
 
+impl ValueInternal for JsNull {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_null(other.to_raw()) }
     }
@@ -216,11 +218,13 @@ impl JsBoolean {
 
 impl Value for JsBoolean { }
 
-impl ValueInternal for JsBoolean {
+impl Managed for JsBoolean {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsBoolean(h) }
+}
 
+impl ValueInternal for JsBoolean {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_boolean(other.to_raw()) }
     }
@@ -255,11 +259,13 @@ pub struct JsString(raw::Local);
 
 impl Value for JsString { }
 
-impl ValueInternal for JsString {
+impl Managed for JsString {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsString(h) }
+}
 
+impl ValueInternal for JsString {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_string(other.to_raw()) }
     }
@@ -353,11 +359,13 @@ impl JsInteger {
 
 impl Value for JsInteger { }
 
-impl ValueInternal for JsInteger {
+impl Managed for JsInteger {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsInteger(h) }
+}
 
+impl ValueInternal for JsInteger {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_integer(other.to_raw()) }
     }
@@ -410,11 +418,13 @@ impl JsNumber {
 
 impl Value for JsNumber { }
 
-impl ValueInternal for JsNumber {
+impl Managed for JsNumber {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsNumber(h) }
+}
 
+impl ValueInternal for JsNumber {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_number(other.to_raw()) }
     }
@@ -449,11 +459,13 @@ pub struct JsObject(raw::Local);
 
 impl Value for JsObject { }
 
-impl ValueInternal for JsObject {
+impl Managed for JsObject {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsObject(h) }
+}
 
+impl ValueInternal for JsObject {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_object(other.to_raw()) }
     }
@@ -558,11 +570,13 @@ impl JsArray {
 
 impl Value for JsArray { }
 
-impl ValueInternal for JsArray {
+impl Managed for JsArray {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsArray(h) }
+}
 
+impl ValueInternal for JsArray {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_array(other.to_raw()) }
     }
@@ -638,11 +652,13 @@ extern "C" fn invoke_nanny_function<U: Value>(info: &CallbackInfo) {
 
 impl Value for JsFunction { }
 
-impl ValueInternal for JsFunction {
+impl Managed for JsFunction {
     fn to_raw(self) -> raw::Local { self.0 }
 
     fn from_raw(h: raw::Local) -> Self { JsFunction(h) }
+}
 
+impl ValueInternal for JsFunction {
     fn is_typeof<Other: Value>(other: Other) -> bool {
         unsafe { neon_sys::tag::is_function(other.to_raw()) }
     }

--- a/src/internal/js/mod.rs
+++ b/src/internal/js/mod.rs
@@ -668,12 +668,6 @@ pub struct JsFunction(raw::Local);
 #[repr(C)]
 pub struct FunctionKernel<T: Value>(fn(Call) -> JsResult<T>);
 
-impl<T: Value> FunctionKernel<T> {
-    pub fn new(kernel: fn(Call) -> JsResult<T>) -> Self {
-        FunctionKernel(kernel)
-    }
-}
-
 impl<T: Value> Kernel<()> for FunctionKernel<T> {
     extern "C" fn callback(info: &CallbackInfo) {
         let mut scope = info.scope();
@@ -706,17 +700,6 @@ impl JsFunction {
             }
         })
     }
-}
-
-pub extern "C" fn call_neon_function<U: Value>(info: &CallbackInfo) {
-    let mut scope = info.scope();
-    exec_function_kernel(info, &mut scope, |call| {
-        let data = info.data();
-        let kernel: fn(Call) -> JsResult<U> = unsafe { mem::transmute(neon_sys::fun::get_kernel(data.to_raw())) };
-        if let Ok(value) = kernel(call) {
-            info.set_return(value);
-        }
-    });
 }
 
 impl Value for JsFunction { }

--- a/src/internal/mem.rs
+++ b/src/internal/mem.rs
@@ -15,7 +15,7 @@ pub trait Managed: Copy {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct Handle<'a, T: Value + 'a> {
+pub struct Handle<'a, T: Managed + 'a> {
     value: T,
     phantom: PhantomData<&'a T>
 }
@@ -26,19 +26,19 @@ impl<'a, T: Value + 'a> Handle<'a, T> {
     }
 }
 
-impl<'a, T: Value + 'a> PartialEq for Handle<'a, T> {
+impl<'a, T: Managed + 'a> PartialEq for Handle<'a, T> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { neon_sys::mem::same_handle(self.to_raw(), other.to_raw()) }
     }
 }
 
-impl<'a, T: Value + 'a> Eq for Handle<'a, T> { }
+impl<'a, T: Managed + 'a> Eq for Handle<'a, T> { }
 
-pub trait HandleInternal<'a, T: Value + 'a> {
+pub trait HandleInternal<'a, T: Managed + 'a> {
     fn new(value: T) -> Handle<'a, T>;
 }
 
-impl<'a, T: Value + 'a> HandleInternal<'a, T> for Handle<'a, T> {
+impl<'a, T: Managed + 'a> HandleInternal<'a, T> for Handle<'a, T> {
     fn new(value: T) -> Handle<'a, T> {
         Handle {
             value: value,
@@ -67,14 +67,14 @@ impl<'a, T: Value> Handle<'a, T> {
     }
 }
 
-impl<'a, T: Value> Deref for Handle<'a, T> {
+impl<'a, T: Managed> Deref for Handle<'a, T> {
     type Target = T;
     fn deref<'b>(&'b self) -> &'b T {
         &self.value
     }
 }
 
-impl<'a, T: Value> DerefMut for Handle<'a, T> {
+impl<'a, T: Managed> DerefMut for Handle<'a, T> {
     fn deref_mut<'b>(&'b mut self) -> &'b mut T {
         &mut self.value
     }

--- a/src/internal/mem.rs
+++ b/src/internal/mem.rs
@@ -55,6 +55,10 @@ impl<'a, T: Value> Handle<'a, T> {
 }
 
 impl<'a, T: Value> Handle<'a, T> {
+    pub fn is_a<U: Value>(&self) -> bool {
+        U::downcast(self.value).is_some()
+    }
+
     pub fn downcast<U: Value>(&self) -> Option<Handle<'a, U>> {
         U::downcast(self.value).map(Handle::new)
     }

--- a/src/internal/mem.rs
+++ b/src/internal/mem.rs
@@ -1,10 +1,17 @@
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use neon_sys;
+use neon_sys::raw;
 use internal::js::{Value, ValueInternal, SuperType};
 use internal::js::error::JsTypeError;
 use internal::vm::{JsResult, Lock, LockState};
 use internal::scope::Scope;
+
+pub trait Managed: Copy {
+    fn to_raw(self) -> raw::Local;
+
+    fn from_raw(h: raw::Local) -> Self;
+}
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/src/internal/vm.rs
+++ b/src/internal/vm.rs
@@ -5,8 +5,8 @@ use neon_sys;
 use neon_sys::raw;
 use neon_sys::buf::Buf;
 use internal::scope::{Scope, RootScope, RootScopeInternal};
-use internal::js::{JsValue, Value, ValueInternal, Object, JsObject, JsFunction};
-use internal::mem::{Handle, HandleInternal};
+use internal::js::{JsValue, Value, Object, JsObject, JsFunction};
+use internal::mem::{Handle, HandleInternal, Managed};
 
 pub struct Throw;
 pub type VmResult<T> = Result<T, Throw>;

--- a/src/internal/vm.rs
+++ b/src/internal/vm.rs
@@ -9,6 +9,7 @@ use neon_sys::buf::Buf;
 use internal::scope::{Scope, RootScope, RootScopeInternal};
 use internal::js::{JsValue, Value, Object, JsObject, JsFunction};
 use internal::js::class::{Class, ClassMetadata};
+use internal::js::error::JsTypeError;
 use internal::mem::{Handle, HandleInternal, Managed};
 
 pub struct Throw;
@@ -139,8 +140,7 @@ impl CallbackInfo {
 
     pub fn require<'b, T: Scope<'b>>(&self, _: &mut T, i: i32) -> JsResult<'b, JsValue> {
         if i < 0 || i >= self.len() {
-            // TODO: throw a type error
-            return Err(Throw);
+            return JsTypeError::throw("not enough arguments");
         }
         unsafe {
             let mut local: raw::Local = mem::zeroed();

--- a/src/internal/vm.rs
+++ b/src/internal/vm.rs
@@ -8,7 +8,7 @@ use neon_sys::raw;
 use neon_sys::buf::Buf;
 use internal::scope::{Scope, RootScope, RootScopeInternal};
 use internal::js::{JsValue, Value, Object, JsObject, JsFunction};
-use internal::js::class::{Class, ClassMetadata};
+use internal::js::class::ClassMetadata;
 use internal::js::error::JsTypeError;
 use internal::mem::{Handle, HandleInternal, Managed};
 

--- a/src/js/class.rs
+++ b/src/js/class.rs
@@ -1,1 +1,2 @@
-pub use internal::js::class::{ClassDescriptor, Class, JsClass};
+pub use internal::js::class::{ClassDescriptor, Class, JsClass, AllocateKernel, ConstructKernel, ConstructorCallKernel, MethodKernel};
+

--- a/src/js/class.rs
+++ b/src/js/class.rs
@@ -1,0 +1,1 @@
+pub use internal::js::class::{ClassDescriptor, Class, JsClass};

--- a/src/js/mod.rs
+++ b/src/js/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod binary;
 pub mod error;
+pub mod class;
 
 pub use internal::js::{Value, Variant, Object, JsValue, JsUndefined, JsNull, JsBoolean, JsInteger, JsNumber, JsString, JsObject, JsArray, JsFunction};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ macro_rules! impl_managed {
 ///
 /// Example:
 ///
-/// ```rust
+/// ```rust,ignore
 /// pub struct Greeter {
 ///     greeting: String
 /// }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -2,4 +2,4 @@
 //!
 //! 
 
-pub use internal::mem::{Handle, LockedHandle};
+pub use internal::mem::{Handle, LockedHandle, Managed};

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,3 +1,3 @@
 //! Abstractions representing the JavaScript virtual machine and its control flow.
 
-pub use internal::vm::{Call, Arguments, Module, Throw, VmResult, JsResult, Lock, lock};
+pub use internal::vm::{Call, ConstructorCall, MethodCall, Arguments, Module, Throw, VmResult, JsResult, Lock, lock};

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,3 +1,3 @@
 //! Abstractions representing the JavaScript virtual machine and its control flow.
 
-pub use internal::vm::{Call, ConstructorCall, MethodCall, Arguments, Module, Throw, VmResult, JsResult, Lock, lock};
+pub use internal::vm::{Call, FunctionCall, Arguments, Module, Throw, VmResult, JsResult, Lock, lock};


### PR DESCRIPTION
This patch implements the ability to define custom JS classes that wrap (owned) Rust data. The classes can implement native methods that operate on the Rust data (and any JS properties too), and they are guaranteed safe by guarding their bodies with a dynamic brand check.