### PR TITLE
JsFunction::construct

### DIFF
--- a/crates/neon-sys/src/fun.rs
+++ b/crates/neon-sys/src/fun.rs
@@ -15,4 +15,7 @@ extern "system" {
     #[link_name = "NeonSys_Fun_Call"]
     pub fn call(out: &mut Local, isolate: *mut c_void, fun: Local, this: Local, argc: i32, argv: *mut c_void) -> bool;
 
+    #[link_name = "NeonSys_Fun_Construct"]
+    pub fn construct(out: &mut Local, isolate: *mut c_void, fun: Local, argc: i32, argv: *mut c_void) -> bool;
+
 }

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -368,6 +368,11 @@ extern "C" bool NeonSys_Fun_Call(v8::Local<v8::Value> *out, v8::Isolate *isolate
   return maybe_result.ToLocal(out);
 }
 
+extern "C" bool NeonSys_Fun_Construct(v8::Local<v8::Object> *out, v8::Isolate *isolate, v8::Local<v8::Function> fun, int32_t argc, v8::Local<v8::Value> argv[]) {
+  v8::MaybeLocal<v8::Object> maybe_result = fun->NewInstance(isolate->GetCurrentContext(), argc, argv);
+  return maybe_result.ToLocal(out);
+}
+
 extern "C" tag_t NeonSys_Tag_Of(v8::Local<v8::Value> val) {
   return val->IsNull()                    ? tag_null
     : val->IsUndefined()                  ? tag_undefined

--- a/crates/neon-sys/src/neon.h
+++ b/crates/neon-sys/src/neon.h
@@ -81,6 +81,7 @@ extern "C" {
   void NeonSys_Fun_ExecKernel(void *kernel, NeonSys_RootScopeCallback callback, v8::FunctionCallbackInfo<v8::Value> *info, void *scope);
   void *NeonSys_Fun_GetKernel(v8::Local<v8::External> obj);
   bool NeonSys_Fun_Call(v8::Local<v8::Value> *out, v8::Isolate *isolate, v8::Local<v8::Function> fun, v8::Local<v8::Value> self, int32_t argc, v8::Local<v8::Value> argv[]);
+  bool NeonSys_Fun_Construct(v8::Local<v8::Object> *out, v8::Isolate *isolate, v8::Local<v8::Function> fun, int32_t argc, v8::Local<v8::Value> argv[]);
 
   typedef void *(*NeonSys_AllocateCallback)(const v8::FunctionCallbackInfo<v8::Value> *info);
   typedef bool (*NeonSys_ConstructCallback)(const v8::FunctionCallbackInfo<v8::Value> *info);

--- a/src/internal/js/class.rs
+++ b/src/internal/js/class.rs
@@ -8,7 +8,7 @@ use neon_sys::raw;
 use internal::mem::{Handle, HandleInternal, Managed};
 use internal::scope::{Scope, ScopeInternal};
 use internal::vm::{Isolate, IsolateInternal, JsResult, VmResult, FunctionCall, CallbackInfo, Lock, LockState, Throw, This, Kernel, exec_function_kernel};
-use internal::js::{Value, ValueInternal, JsFunction, JsObject, JsValue, JsUndefined, build};
+use internal::js::{Value, ValueInternal, JsFunction, JsObject, Object, JsValue, JsUndefined, build};
 use internal::js::error::{JsError, Kind};
 
 #[repr(C)]
@@ -218,6 +218,8 @@ impl<T: Class> This for T {
     }
 }
 
+impl<T: Class> Object for T { }
+
 pub trait ClassInternal: Class {
     fn metadata_opt<'a, T: Scope<'a>>(scope: &mut T) -> Option<ClassMetadata> {
         scope.isolate()
@@ -346,7 +348,7 @@ impl<T: Class> JsClass<T> {
         }
     }
 
-    pub fn constructor<'a, U: Scope<'a>>(&self, _: &mut U) -> JsResult<'a, JsFunction> {
+    pub fn constructor<'a, U: Scope<'a>>(&self, _: &mut U) -> JsResult<'a, JsFunction<T>> {
         build(|out| {
             unsafe {
                 neon_sys::class::constructor(out, self.to_raw())

--- a/tests/lib/functions.js
+++ b/tests/lib/functions.js
@@ -2,15 +2,19 @@ var addon = require('../native');
 var assert = require('chai').assert;
 
 describe('JsFunction', function() {
-  it('should return a JsFunction built in Rust', function () {
+  it('return a JsFunction built in Rust', function () {
     assert.isFunction(addon.return_js_function());
   });
 
-  it('should return a JsFunction built in Rust that implements x => x + 1', function () {
+  it('return a JsFunction built in Rust that implements x => x + 1', function () {
     assert.equal(addon.return_js_function()(41), 42);
   });
 
-  it('should call a JsFunction built in JS that implements x => x + 1', function () {
+  it('call a JsFunction built in JS that implements x => x + 1', function () {
     assert.equal(addon.call_js_function(function(x) { return x + 1 }), 17);
+  });
+
+  it('new a JsFunction', function () {
+    assert.equal(addon.construct_js_function(Date), 1970);
   });
 });

--- a/tests/native/src/js/functions.rs
+++ b/tests/native/src/js/functions.rs
@@ -1,6 +1,6 @@
 use neon::vm::{Call, JsResult};
 use neon::mem::Handle;
-use neon::js::{JsNumber, JsNull, JsFunction};
+use neon::js::{JsNumber, JsNull, JsFunction, Object, JsValue};
 
 fn add1(call: Call) -> JsResult<JsNumber> {
     let scope = call.scope;
@@ -16,5 +16,15 @@ pub fn call_js_function(call: Call) -> JsResult<JsNumber> {
     let scope = call.scope;
     let f = try!(try!(call.arguments.require(scope, 0)).check::<JsFunction>());
     let args: Vec<Handle<JsNumber>> = vec![JsNumber::new(scope, 16.0)];
-    f.call(scope, JsNull::new(), args)
+    try!(f.call(scope, JsNull::new(), args)).check::<JsNumber>()
+}
+
+pub fn construct_js_function(call: Call) -> JsResult<JsNumber> {
+    let scope = call.scope;
+    let f = try!(try!(call.arguments.require(scope, 0)).check::<JsFunction>());
+    let zero = JsNumber::new(scope, 0.0);
+    let o = try!(f.construct(scope, vec![zero]));
+    let get_utc_full_year_method = try!(try!(o.get(scope, "getUTCFullYear")).check::<JsFunction>());
+    let args: Vec<Handle<JsValue>> = vec![];
+    try!(get_utc_full_year_method.call(scope, o.upcast::<JsValue>(), args)).check::<JsNumber>()
 }

--- a/tests/native/src/lib.rs
+++ b/tests/native/src/lib.rs
@@ -38,7 +38,6 @@ register_module!(m, {
 
     try!(m.export("return_js_function", return_js_function));
     try!(m.export("call_js_function", call_js_function));
+    try!(m.export("construct_js_function", construct_js_function));
     Ok(())
 });
-
-


### PR DESCRIPTION
Implementation of #61: enable constructing new instances from `JsFunction`s, including those of custom classes, with precise return types.