### PR TITLE
Fix warnings

### DIFF
--- a/src/internal/js/class.rs
+++ b/src/internal/js/class.rs
@@ -249,7 +249,7 @@ pub trait ClassInternal: Class {
 
             let (call_callback, call_kernel) = match descriptor.call {
                 Some(k) => k.pair(),
-                None    => (mem::transmute(ConstructorCallKernel::unimplemented::<Self>), null_mut())
+                None    => (mem::transmute(ConstructorCallKernel::unimplemented::<Self> as usize), null_mut())
             };
 
             let metadata_pointer = neon_sys::class::create_base(isolate,

--- a/src/internal/mem.rs
+++ b/src/internal/mem.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use neon_sys;
 use neon_sys::raw;
-use internal::js::{Value, ValueInternal, SuperType};
+use internal::js::{Value, SuperType};
 use internal::js::error::{JsError, Kind};
 use internal::vm::{JsResult, Lock, LockState};
 use internal::scope::Scope;

--- a/src/internal/vm.rs
+++ b/src/internal/vm.rs
@@ -62,7 +62,7 @@ impl IsolateInternal for Isolate {
             let b: Box<ClassMap> = Box::new(ClassMap::new());
             let raw = Box::into_raw(b);
             ptr = unsafe { mem::transmute(raw) };
-            let free_map: *mut c_void = unsafe { mem::transmute(drop_class_map) };
+            let free_map: *mut c_void = unsafe { mem::transmute(drop_class_map as usize) };
             unsafe {
                 neon_sys::class::set_class_map(self.to_raw(), ptr, free_map);
             }
@@ -176,7 +176,7 @@ impl<'a> Module<'a> {
         let mut scope = RootScope::new(unsafe { mem::transmute(neon_sys::object::get_isolate(exports.to_raw())) });
         unsafe {
             let kernel: *mut c_void = mem::transmute(init);
-            let callback: extern "C" fn(*mut c_void, *mut c_void, *mut c_void) = mem::transmute(module_callback);
+            let callback: extern "C" fn(*mut c_void, *mut c_void, *mut c_void) = mem::transmute(module_callback as usize);
             let exports: raw::Local = exports.to_raw();
             let scope: *mut c_void = mem::transmute(&mut scope);
             neon_sys::module::exec_kernel(kernel, callback, exports, scope);
@@ -256,7 +256,7 @@ pub trait Kernel<T: Clone + Copy + Sized>: Sized {
 
     fn pair(self) -> (*mut c_void, *mut c_void) {
         unsafe {
-            (mem::transmute(Self::callback), self.as_raw())
+            (mem::transmute(Self::callback as usize), self.as_raw())
         }
     }
 }


### PR DESCRIPTION
This PR fixes some warnings related to unused imports and `transmute` with `fn` items (per rust-lang/rust/issues/19925).