### PR TITLE
Fix spurious improper_ctypes warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod sys {
 macro_rules! register_module {
     ($module:ident, $init:block) => {
         // Mark this function as a global constructor (like C++).
+        #[allow(improper_ctypes)]
         #[cfg_attr(target_os = "linux", link_section = ".ctors")]
         #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
         #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]


### PR DESCRIPTION
This PR fixes seemingly spurious warnings about improper ctypes that show up when neon macros are used. Maybe there is a better way to fix this but I couldn't figure out how.